### PR TITLE
Add Lean Solution link button to home page

### DIFF
--- a/src/components/Portrait.jsx
+++ b/src/components/Portrait.jsx
@@ -8,7 +8,7 @@ import { Box, Grid, Typography } from "@mui/material";
 import { useTheme } from "@mui/material/styles";
 import Paper from "@mui/material/Paper";
 import Avatar from "@mui/material/Avatar";
-import { RiLinkedinLine } from "react-icons/ri";
+import { RiLinkedinLine, RiRocketLine } from "react-icons/ri";
 import IMAGES from "../assets/Images";
 import ownerConstants from "../constants/ownerConstants";
 import PrimaryIconButton from "./Navigation/PrimaryIconButton";
@@ -173,6 +173,13 @@ export default function Portrait() {
               url="https://www.linkedin.com/in/tonio-suessdorf-942b99184/"
             >
               <RiLinkedinLine style={{ fontSize: "1.5rem" }} />
+            </CustomIconButton>
+
+            <CustomIconButton
+              aria-label="Lean Solution project"
+              url="https://lean-solution.vercel.app"
+            >
+              <RiRocketLine style={{ fontSize: "1.5rem" }} />
             </CustomIconButton>
 
             <EmailContactButton />


### PR DESCRIPTION
## Summary

- Adds a third icon button (rocket icon) to the home page button row, linking to https://lean-solution.vercel.app
- Uses the existing `CustomIconButton` / `PrimaryIconButton` pattern — no new abstractions
- Opens in a new tab with `target="_blank"` and `rel="noopener noreferrer"`, consistent with the LinkedIn button

## Test plan

- [x] Home page renders three buttons in a row with consistent circular bordered styling
- [x] Rocket button links to https://lean-solution.vercel.app and opens in a new tab
- [x] LinkedIn and email buttons are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)